### PR TITLE
Use fileURLToPath for src alias

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': new URL('./src', import.meta.url).pathname,
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
## Summary
- switch Vite alias to use `fileURLToPath(new URL('./src', import.meta.url))`

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'node:url' or its corresponding type declarations)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b0d7123ee4833291ed64f50b89a7db