### PR TITLE
Fix build failure by removing Node URL import from Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      // Map `@` to the project src directory without relying on Node.js
+      // URL utilities so the config can compile in environments that
+      // lack Node type definitions.
+      '@': '/src',
     },
   },
 })


### PR DESCRIPTION
## Summary
- Remove Node-specific URL import and use a simple `/src` alias to avoid missing Node type definitions
- Add comments explaining the alias adjustment

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0da373d6083329f34bc191b914815