### PR TITLE
Fix base path in Vite config for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '\gcuchemclub',
+  base: '/gcu-chem-club/',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- set `base` to `/gcu-chem-club/` so built assets resolve correctly when deployed to GitHub Pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0eaa03e9483329809bef5b60793c3