### PR TITLE
Fix Add to Calendar event time

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,8 +19,8 @@ function makeDateTimeBlock(date: string, startClock: string, endClock: string) {
   // startClock / endClock like "18:00:00"
   const day = yyyymmdd(date);
   return {
-    gStart: `${day}T${startClock}`,
-    gEnd: `${day}T${endClock}`,
+    gStart: `${day}T${startClock.replaceAll(":", "")}`,
+    gEnd: `${day}T${endClock.replaceAll(":", "")}`,
     icsStart: `DTSTART;TZID=${TZID}:${day}T${startClock.replaceAll(":", "")}`,
     icsEnd: `DTEND;TZID=${TZID}:${day}T${endClock.replaceAll(":", "")}`,
   };


### PR DESCRIPTION
## Summary
- remove colon characters when building Google Calendar timestamps to prevent 10-minute offset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0ef2e11988332960edaaf7fd2f933