### PR TITLE
Fix calendar button overflow and icon size

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,10 +160,18 @@ function EventRow({ event, location }: { event: { date: string; title: string };
       <div className="md:col-span-3 text-sm">6:00–7:00 PM</div>
       <div className="md:col-span-2 text-sm">{event.title.split(" • ")[1]}</div>
       <div className="md:col-span-2 flex gap-2">
-        <Button onClick={onGoogle} size="sm" className="rounded-2xl bg-emerald-600 hover:bg-emerald-500 text-white border border-white/20">
-          <CalendarPlus className="w-4 h-4 mr-2" />Add to Calendar
+        <Button
+          onClick={onGoogle}
+          size="sm"
+          className="rounded-2xl bg-emerald-600 hover:bg-emerald-500 text-white border border-white/20 text-xs whitespace-nowrap"
+        >
+          <CalendarPlus className="w-5 h-5 mr-2" />Add to Calendar
         </Button>
-        <Button onClick={onICS} size="sm" className="rounded-2xl bg-white/10 hover:bg-white/20 text-white border border-white/20">
+        <Button
+          onClick={onICS}
+          size="sm"
+          className="rounded-2xl bg-white/10 hover:bg-white/20 text-white border border-white/20 text-xs whitespace-nowrap"
+        >
           .ics file
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- prevent calendar buttons text from wrapping out of bounds
- enlarge calendar icon for better visibility

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0f0b485f083328372e87964764258